### PR TITLE
Update `huggingface-hub` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ tqdm = "^4.65.0"
 scipy = "^1.11.2"
 rasterio = "^1.3.8"
 requests = "^2.26.0"
-huggingface_hub = "^0.19.3"
+huggingface_hub = ">=0.19.3"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "geobench"
-version = "0.0.3"
+version = "1.0.1"
 description = "A benchmark designed to advance foundation models for Earth monitoring, tailored for remote sensing. It encompasses six classification and six segmentation tasks, curated for precision and model evaluation. The package also features a comprehensive evaluation methodology and showcases results from 20 established baseline models."
 authors = [
     "Alexandre Lacoste <alexandre.lacoste@servicenow.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "geobench"
 version = "0.0.3"


### PR DESCRIPTION
This PR updates the `huggingface-hub` version to avoid pinning it down to an old version. Solves #17.

I also updated the `pyproject.toml` to be able to install it via `pip` from github.